### PR TITLE
Fix bottle deprecation warning

### DIFF
--- a/Formula/dip.rb
+++ b/Formula/dip.rb
@@ -4,7 +4,6 @@ class Dip < Formula
   desc "dip CLI gives the native-like interaction with Docker-Compose applications"
   homepage "https://github.com/bibendi/dip"
   version VERSION
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/bibendi/dip/releases/download/v#{VERSION}/dip-Darwin-x86_64"


### PR DESCRIPTION
`bottle` DSL is no-op outside of the core. It's safe just to remove it.

You can find more info [here](https://github.com/Homebrew/discussions/discussions/2311).