### PR TITLE
Warning: Calling bottle :unneeded is deprecated! There is no replacement.

### DIFF
--- a/Formula/dip.rb
+++ b/Formula/dip.rb
@@ -4,7 +4,6 @@ class Dip < Formula
   desc "dip CLI gives the native-like interaction with Docker-Compose applications"
   homepage "https://github.com/bibendi/dip"
   version VERSION
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/bibendi/dip/releases/download/v#{VERSION}/dip-Darwin-x86_64"


### PR DESCRIPTION
I got a warning, so I fixed it.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the bibendi/dip tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/bibendi/homebrew-dip/Formula/dip.rb:7
```